### PR TITLE
[search] add: fulltext index on db column `post`.`content`

### DIFF
--- a/drizzle/0003_search_add_fulltext_idx.sql
+++ b/drizzle/0003_search_add_fulltext_idx.sql
@@ -1,0 +1,2 @@
+-- Custom SQL migration file, put your code below! --
+CREATE FULLTEXT INDEX content_fulltext_idx ON post(content)

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1758817039794,
       "tag": "0002_left_morlun",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1760332315021,
+      "tag": "0003_search_add_fulltext_idx",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
resolves #60 

Added custom migration hook to create fulltext index on post table on content column. DrizzleORM does not natively support FULLTEXT index for MySQL ([ref](https://orm.drizzle.team/docs/indexes-constraints#indexes) to drizzle docs), so the workaround is to write a custom SQL script and have that run after the ORM generated migrations. These are ordered by prefix number (e.x. 0003) and are tracked in `_journal.json` in `drizzle/meta`.

<img width="1920" height="1080" alt="Screenshot From 2025-10-13 01-24-10" src="https://github.com/user-attachments/assets/ac06587d-931c-47ee-ae76-97eb7d3354bb" />
