### PR TITLE
[search] change FULLTEXT index target column

### DIFF
--- a/migrations/overrides.sql
+++ b/migrations/overrides.sql
@@ -1,3 +1,3 @@
 -- Use this file to manually define additional tables, constrains, indices, etc.
 -- Do not delete these comments.
-CREATE FULLTEXT INDEX `content_idx` ON `post` (`content`);
+CREATE FULLTEXT INDEX `content_idx` ON `post` (`textContent`);


### PR DESCRIPTION
resolves #124 

Changed `content` to `textContent` to target the correct text version