### PR TITLE
Make Post.tsx readonly option + API call to remove post + RemovePost.tsx Component created & added to admin page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { posts, profiles, events, flags } from "~/server/db/schema";
 import { sql } from "drizzle-orm";
 
 import Post from "~/components/Post";
+import RemovePost from "~/components/RemovePost";
 
 export default async function AdminPage() {
   const results = await db
@@ -30,25 +31,36 @@ export default async function AdminPage() {
         </p>
       ) : (
         results.map(({ post, author, event, flagCount }) => (
-          <Post
+          <div
             key={post.id}
-            post={{
-              id: post.id,
-              createdAt: post.createdAt,
-              updatedAt: post.updatedAt,
-              content: post.content,
-              authorId: post.authorId,
-              eventId: post.eventId,
-              score: post.score,
-              commentCount: post.commentCount,
-              flagCount: Number(flagCount) ?? 0,
-            }}
-            profile={author!}
-            event={event!}
-            vote={null}
-            session={null}
-            readonly 
-          />
+            className="flex flex-col gap-2 rounded-lg border border-gray-200 p-4 shadow-sm"
+          >
+            <Post
+              key={post.id}
+              post={{
+                id: post.id,
+                createdAt: post.createdAt,
+                updatedAt: post.updatedAt,
+                content: post.content,
+                authorId: post.authorId,
+                eventId: post.eventId,
+                score: post.score,
+                commentCount: post.commentCount,
+                flagCount: Number(flagCount) ?? 0,
+              }}
+              profile={author!}
+              event={event!}
+              vote={null}
+              session={null}
+              readonly
+            />
+            <div className="flex justify-end">
+              <RemovePost
+                postId={post.id}
+                userId={author?.id ?? "admin"} // replace with admin ID if applicable
+              />
+            </div>
+          </div>
         ))
       )}
     </div>

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,82 @@
+import { db } from "~/server/db";
+import {
+  posts,
+  postVotes,
+  comments,
+  commentVotes,
+  flags,
+  tagsToPosts,
+} from "~/server/db/schema";
+import { eq, and, inArray } from "drizzle-orm";
+
+// Delete a post and all associated data
+// Expects userId, postId
+export async function DELETE(request: Request) {
+  try {
+    const data: unknown = await request.json();
+
+    if (
+      !(
+        typeof data === "object" &&
+        data !== null &&
+        "userId" in data &&
+        typeof data.userId === "string" &&
+        "postId" in data &&
+        typeof data.postId === "string"
+      )
+    ) {
+      return new Response("Missing userId or postId", { status: 400 });
+    }
+
+    const { userId, postId } = data;
+
+    // Ensure post exists and belongs to the user
+    const existingPost = await db
+      .select()
+      .from(posts)
+      .where(and(eq(posts.id, postId), eq(posts.authorId, userId)))
+      .limit(1);
+
+    if (existingPost.length === 0) {
+      return new Response("Post not found or unauthorized", { status: 403 });
+    }
+
+    // Start transaction
+    await db.transaction(async (tx) => {
+      // Get all comment IDs for this post (for cascading deletions)
+      const commentIds = (
+        await tx
+          .select({ id: comments.id })
+          .from(comments)
+          .where(eq(comments.postId, postId))
+      ).map((c) => c.id);
+
+      // Delete comment votes tied to those comments
+      if (commentIds.length > 0) {
+        await tx.delete(commentVotes).where(inArray(commentVotes.commentId, commentIds));
+      }
+
+      // Delete post votes
+      await tx.delete(postVotes).where(eq(postVotes.postId, postId));
+
+      // Delete flags
+      await tx.delete(flags).where(eq(flags.postId, postId));
+
+      // Delete tags linking this post
+      await tx.delete(tagsToPosts).where(eq(tagsToPosts.postId, postId));
+
+      // Delete comments themselves
+      await tx.delete(comments).where(eq(comments.postId, postId));
+
+      // Finally, delete the post itself
+      await tx.delete(posts).where(and(eq(posts.id, postId), eq(posts.authorId, userId)));
+    });
+
+    return new Response("Post and related data deleted successfully", {
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Error deleting post:", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -236,16 +236,17 @@ export default async function HomePage({
                 <span className="relative">
                   <PiCalendarBlank />
                   <span className="absolute inset-0 top-1/2 w-full -translate-y-1/2 pt-px text-center text-[0.55rem] font-bold">
-                    {getDate(event!.start)}
+                    {event?.start ? getDate(event.start) : null}
                   </span>
                 </span>
 
                 <span className="flex min-w-0 flex-1 flex-col">
                   <span className="-mt-0.5 overflow-x-hidden text-sm/[1.25] overflow-ellipsis">
-                    {event!.title}
+                    {event?.title ?? "No event"}
+                    {event ? formatEventTime(event) : ""}
                   </span>
                   <span className="text-[0.6rem]/[1] font-bold text-gray-600">
-                    {formatEventTime(event!)}
+                    {event ? formatEventTime(event) : ""}
                   </span>
                 </span>
               </Link>
@@ -259,24 +260,24 @@ export default async function HomePage({
                 </button>
               </ShareDropdown>
 
-                <div className="ml-auto text-xs">
-                  <VoteButton
-                    target={{ postId: post.id }}
-                    score={post.score}
-                    value={vote}
-                  />
-                </div> 
+              <div className="ml-auto text-xs">
+                <VoteButton
+                  target={{ postId: post.id }}
+                  score={post.score}
+                  value={vote}
+                />
               </div>
+            </div>
           </article>
-        ))}
+        ),
+      )}
 
-
-        {postsResult.size === 0 && (
-          <p className="max-w-prose text-center text-sm text-gray-600">
-            There aren&rsquo;t any posts to display yet. Try signing in and
-            publishing some!
-          </p>
-        )}
+      {postsResult.size === 0 && (
+        <p className="max-w-prose text-center text-sm text-gray-600">
+          There aren&rsquo;t any posts to display yet. Try signing in and
+          publishing some!
+        </p>
+      )}
     </div>
-  ); 
-} 
+  );
+}

--- a/src/components/RemovePost.tsx
+++ b/src/components/RemovePost.tsx
@@ -1,31 +1,26 @@
 "use client";
-
 import { useState } from "react";
-
 {
   /* rest of the code should have a remove post logic where the post is removed if readonly is true and the button is clicked */
 }
 {
   /* if the button is clicked, then it should called the remove post api to remove the post */
 }
-
 interface RemovePostProps {
   postId: string;
   userId: string;
 }
-
 export default function RemovePost({ postId, userId }: RemovePostProps) {
   const [removed, setRemoved] = useState(false);
-
   const handleRemove = async () => {
     if (removed) return;
 
-    const res = await fetch(`/api/posts/${postId}`, {
+    const res = await fetch(`/api/posts/`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${userId}`,
       },
+      body: JSON.stringify({ userId, postId }),
     });
 
     if (res.ok) {
@@ -34,7 +29,11 @@ export default function RemovePost({ postId, userId }: RemovePostProps) {
   };
 
   return (
-    <button onClick={handleRemove} disabled={removed}>
+    <button
+      onClick={handleRemove}
+      disabled={removed}
+      className={`rounded px-3 py-1 ${removed ? "cursor-not-allowed bg-gray-300" : "bg-red-500 text-white hover:bg-red-600"}`}
+    >
       {removed ? "Post Removed" : "Remove Post"}
     </button>
   );


### PR DESCRIPTION
Changed up post.tsx component to have a read only option. Created an API call for the RemovePost.tsx component so that when the button is clicked, the post and all relational data in the database is deleted. The RemovePost.tsx Component was also created, fixed up, and then added to the admin page.

Now, when the code is run, the flag buttons work, so do the api calls. When a post is flagged, it is added onto the admin page in descending order so that if a post has more flags, it is higher up on the admin page. After that, when reviewing the post on the admin page, the post component is the same, and now all the buttons on the post.tsx component are read only. There is also a removepost button that was added to the post component on the admin page that removes all the information on the database that relates to that post.