### PR TITLE
add vote-based interest updates and profile interest editing

### DIFF
--- a/src/app/profile/[profileId]/edit/page.tsx
+++ b/src/app/profile/[profileId]/edit/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import FilePicker from "~/components/FilePicker";
+import { eq } from "drizzle-orm";
+import EditInterests from "~/components/EditInterests";
 import editProfile from "~/server/actions/editProfile";
+import { getUserInterests } from "~/server/actions/interests";
+import getAllTags from "~/server/actions/getAllTags";
 import { expectSession } from "~/server/auth";
 import { hasPermissions } from "~/server/db/permissions";
-
-//This is the form field page where users are redirected to to edit their profiles.
 
 export default async function EditProfilePage({
   params,
@@ -47,6 +48,12 @@ export default async function EditProfilePage({
   if (!profile) {
     notFound();
   }
+
+  // Fetch interests and tags (only for user profiles, not orgs)
+  const isUserProfile = profile.id === session.userProfileId;
+  const [interests, allTags] = isUserProfile
+    ? await Promise.all([getUserInterests(), getAllTags()])
+    : [[], []];
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-10">
@@ -94,6 +101,14 @@ export default async function EditProfilePage({
             className="mt-1 block w-full rounded-md border px-3 py-2"
           />
         </div>
+
+        {/* Interests Section - only for user profiles */}
+        {isUserProfile && (
+          <div className="border-t pt-4">
+            <EditInterests currentInterests={interests} allTags={allTags} />
+          </div>
+        )}
+
         <div className="flex items-center gap-3">
           <button
             type="submit"

--- a/src/components/EditInterests.tsx
+++ b/src/components/EditInterests.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { PiPlusBold, PiXBold } from "react-icons/pi";
+import { addInterest, removeInterest } from "~/server/actions/interests";
+import type { schema } from "~/server/db/schema";
+
+interface Props {
+  currentInterests: {
+    tagId: string;
+    tagName: string;
+    weight: string;
+  }[];
+  allTags: (typeof schema.tags.$inferSelect)[];
+}
+
+export default function EditInterests({ currentInterests, allTags }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [showAddMenu, setShowAddMenu] = useState(false);
+
+  const currentTagIds = new Set(currentInterests.map((i) => i.tagId));
+  const availableTags = allTags.filter(
+    (t) => !currentTagIds.has(t.id) && t.depth > 0,
+  );
+
+  const handleRemove = (tagId: string) => {
+    startTransition(async () => {
+      await removeInterest(tagId);
+    });
+  };
+
+  const handleAdd = (tagId: string) => {
+    startTransition(async () => {
+      await addInterest(tagId);
+      setShowAddMenu(false);
+    });
+  };
+
+  // Group available tags by category
+  const categories = allTags.filter((t) => t.depth === 0);
+
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm font-medium">Your Interests</label>
+
+      {/* Current Interests */}
+      <div className="flex flex-wrap gap-2">
+        {currentInterests.length === 0 ? (
+          <p className="text-sm text-gray-500">No interests selected yet.</p>
+        ) : (
+          currentInterests.map((interest) => (
+            <span
+              key={interest.tagId}
+              className="flex items-center gap-1 rounded-full bg-sky-100 px-3 py-1 text-sm text-sky-800"
+            >
+              {interest.tagName}
+              <span className="text-xs text-sky-600">({interest.weight})</span>
+              <button
+                type="button"
+                onClick={() => handleRemove(interest.tagId)}
+                disabled={isPending}
+                className="ml-1 rounded-full p-0.5 hover:bg-sky-200 disabled:opacity-50"
+              >
+                <PiXBold className="h-3 w-3" />
+              </button>
+            </span>
+          ))
+        )}
+      </div>
+
+      {/* Add Interest Button */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setShowAddMenu(!showAddMenu)}
+          disabled={isPending || availableTags.length === 0}
+          className="flex items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          <PiPlusBold /> Add Interest
+        </button>
+
+        {/* Dropdown Menu */}
+        {showAddMenu && (
+          <div className="absolute top-full left-0 z-10 mt-1 max-h-64 w-72 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg">
+            {categories.map((category) => {
+              const children = availableTags.filter(
+                (t) => t.lft > category.lft && t.rgt < category.rgt,
+              );
+
+              if (children.length === 0) return null;
+
+              return (
+                <div key={category.id} className="border-b border-gray-100 p-2">
+                  <p className="mb-1 text-xs font-semibold text-gray-500 uppercase">
+                    {category.name}
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {children.map((tag) => (
+                      <button
+                        key={tag.id}
+                        type="button"
+                        onClick={() => handleAdd(tag.id)}
+                        disabled={isPending}
+                        className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-sky-100 hover:text-sky-800 disabled:opacity-50"
+                      >
+                        {tag.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* Close button */}
+            <button
+              type="button"
+              onClick={() => setShowAddMenu(false)}
+              className="w-full p-2 text-center text-sm text-gray-500 hover:bg-gray-50"
+            >
+              Close
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/recommendations/constants.ts
+++ b/src/lib/recommendations/constants.ts
@@ -4,20 +4,9 @@ export const INTEREST_WEIGHTS = {
 
   // Voting signals
   UPVOTE: 0.5,
-  DOWNVOTE_INCORRECT: -0.1,
-  DOWNVOTE_HARMFUL: -0.3,
-  DOWNVOTE_SPAM: -0.2,
+  DOWNVOTE: -0.5,
 
   // Bounds
   MIN_WEIGHT: 0,
   MAX_WEIGHT: 10,
 } as const;
-
-export type VoteType = "up" | "down.incorrect" | "down.harmful" | "down.spam";
-
-export const VOTE_WEIGHT_MAP: Record<VoteType, number> = {
-  up: INTEREST_WEIGHTS.UPVOTE,
-  "down.incorrect": INTEREST_WEIGHTS.DOWNVOTE_INCORRECT,
-  "down.harmful": INTEREST_WEIGHTS.DOWNVOTE_HARMFUL,
-  "down.spam": INTEREST_WEIGHTS.DOWNVOTE_SPAM,
-};

--- a/src/server/actions/interests.ts
+++ b/src/server/actions/interests.ts
@@ -1,15 +1,10 @@
-// This file contains server actions related to user interests and onboarding
 "use server";
 
 import { eq, sql } from "drizzle-orm";
 import { db } from "~/server/db";
-import { tags, userInterests, users } from "~/server/db/schema/tables";
+import { tags, userInterests, users, postTags } from "~/server/db/schema/tables";
 import { getSession } from "~/server/auth";
-import {
-  INTEREST_WEIGHTS,
-  VOTE_WEIGHT_MAP,
-  type VoteType,
-} from "~/lib/recommendations/constants";
+import { INTEREST_WEIGHTS } from "~/lib/recommendations/constants";
 import { revalidatePath } from "next/cache";
 
 /**
@@ -22,7 +17,6 @@ export async function saveOnboardingInterests(tagIds: string[]) {
   }
 
   await db.transaction(async (tx) => {
-    // Insert selected interests with initial weight
     if (tagIds.length > 0) {
       await tx
         .insert(userInterests)
@@ -31,7 +25,7 @@ export async function saveOnboardingInterests(tagIds: string[]) {
             userProfileId: session.userProfileId,
             tagId,
             weight: INTEREST_WEIGHTS.INITIAL_SELECTION.toString(),
-          })),
+          }))
         )
         .onDuplicateKeyUpdate({
           set: {
@@ -40,7 +34,6 @@ export async function saveOnboardingInterests(tagIds: string[]) {
         });
     }
 
-    // Mark onboarding complete
     await tx
       .update(users)
       .set({ onboardingCompleted: true })
@@ -70,35 +63,60 @@ export async function skipOnboarding() {
 /**
  * Update interest weights based on voting behavior
  * Call this after a user votes on a post
+ * 
+ * @param postId - The post being voted on
+ * @param isUpvote - true for upvote, false for downvote
+ * @param previousVoteWasUpvote - null if no previous vote, true/false for previous vote type
  */
 export async function updateInterestsFromVote(
-  postTagIds: string[],
-  voteType: VoteType,
-  previousVote?: VoteType | null,
+  postId: string,
+  isUpvote: boolean,
+  previousVoteWasUpvote: boolean | null
 ) {
   const session = await getSession({});
-  if (!session?.userProfileId || postTagIds.length === 0) {
+  if (!session?.userProfileId) {
     return;
   }
 
-  const weightDelta = VOTE_WEIGHT_MAP[voteType];
-  const previousDelta = previousVote ? VOTE_WEIGHT_MAP[previousVote] : 0;
-  const netDelta = weightDelta - previousDelta;
+  // Get all tags for this post
+  const postTagsResult = await db
+    .select({ tagId: postTags.tagId })
+    .from(postTags)
+    .where(eq(postTags.postId, postId));
 
-  if (netDelta === 0) return;
+  if (postTagsResult.length === 0) {
+    return; // Post has no tags, nothing to update
+  }
 
+  // Calculate weight delta
+  let weightDelta = 0;
+  
+  if (previousVoteWasUpvote === null) {
+    // New vote
+    weightDelta = isUpvote ? INTEREST_WEIGHTS.UPVOTE : INTEREST_WEIGHTS.DOWNVOTE;
+  } else if (previousVoteWasUpvote !== isUpvote) {
+    // Changed vote (upvote to downvote or vice versa)
+    weightDelta = isUpvote 
+      ? INTEREST_WEIGHTS.UPVOTE - INTEREST_WEIGHTS.DOWNVOTE  // +1.0
+      : INTEREST_WEIGHTS.DOWNVOTE - INTEREST_WEIGHTS.UPVOTE; // -1.0
+  } else {
+    // Same vote, no change
+    return;
+  }
+
+  // Update weights for all tags on this post
   await db.transaction(async (tx) => {
-    for (const tagId of postTagIds) {
+    for (const { tagId } of postTagsResult) {
       await tx
         .insert(userInterests)
         .values({
           userProfileId: session.userProfileId,
           tagId,
-          weight: Math.max(INTEREST_WEIGHTS.MIN_WEIGHT, netDelta).toString(),
+          weight: Math.max(INTEREST_WEIGHTS.MIN_WEIGHT, weightDelta).toString(),
         })
         .onDuplicateKeyUpdate({
           set: {
-            weight: sql`GREATEST(${INTEREST_WEIGHTS.MIN_WEIGHT}, LEAST(${INTEREST_WEIGHTS.MAX_WEIGHT}, ${userInterests.weight} + ${netDelta}))`,
+            weight: sql`GREATEST(${INTEREST_WEIGHTS.MIN_WEIGHT}, LEAST(${INTEREST_WEIGHTS.MAX_WEIGHT}, ${userInterests.weight} + ${weightDelta}))`,
           },
         });
     }

--- a/src/server/actions/interests.ts
+++ b/src/server/actions/interests.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { eq, sql } from "drizzle-orm";
-import { db } from "~/server/db";
-import { tags, userInterests, users, postTags } from "~/server/db/schema/tables";
-import { getSession } from "~/server/auth";
-import { INTEREST_WEIGHTS } from "~/lib/recommendations/constants";
+import { and, eq, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { INTEREST_WEIGHTS } from "~/lib/recommendations/constants";
+import { getSession } from "~/server/auth";
+import { db } from "~/server/db";
+import { postTags, tags, userInterests, users } from "~/server/db/schema/tables";
 
 /**
  * Save initial interests during onboarding
@@ -62,11 +62,6 @@ export async function skipOnboarding() {
 
 /**
  * Update interest weights based on voting behavior
- * Call this after a user votes on a post
- * 
- * @param postId - The post being voted on
- * @param isUpvote - true for upvote, false for downvote
- * @param previousVoteWasUpvote - null if no previous vote, true/false for previous vote type
  */
 export async function updateInterestsFromVote(
   postId: string,
@@ -85,22 +80,19 @@ export async function updateInterestsFromVote(
     .where(eq(postTags.postId, postId));
 
   if (postTagsResult.length === 0) {
-    return; // Post has no tags, nothing to update
+    return;
   }
 
   // Calculate weight delta
   let weightDelta = 0;
-  
+
   if (previousVoteWasUpvote === null) {
-    // New vote
     weightDelta = isUpvote ? INTEREST_WEIGHTS.UPVOTE : INTEREST_WEIGHTS.DOWNVOTE;
   } else if (previousVoteWasUpvote !== isUpvote) {
-    // Changed vote (upvote to downvote or vice versa)
-    weightDelta = isUpvote 
-      ? INTEREST_WEIGHTS.UPVOTE - INTEREST_WEIGHTS.DOWNVOTE  // +1.0
-      : INTEREST_WEIGHTS.DOWNVOTE - INTEREST_WEIGHTS.UPVOTE; // -1.0
+    weightDelta = isUpvote
+      ? INTEREST_WEIGHTS.UPVOTE - INTEREST_WEIGHTS.DOWNVOTE
+      : INTEREST_WEIGHTS.DOWNVOTE - INTEREST_WEIGHTS.UPVOTE;
   } else {
-    // Same vote, no change
     return;
   }
 
@@ -120,6 +112,16 @@ export async function updateInterestsFromVote(
           },
         });
     }
+
+    // Clean up: delete any interests with weight 0
+    await tx
+      .delete(userInterests)
+      .where(
+        and(
+          eq(userInterests.userProfileId, session.userProfileId),
+          eq(userInterests.weight, "0.00")
+        )
+      );
   });
 }
 
@@ -142,4 +144,50 @@ export async function getUserInterests() {
     .innerJoin(tags, eq(tags.id, userInterests.tagId))
     .where(eq(userInterests.userProfileId, session.userProfileId))
     .orderBy(sql`${userInterests.weight} DESC`);
+}
+
+/**
+ * Add a single interest
+ */
+export async function addInterest(tagId: string) {
+  const session = await getSession({});
+  if (!session?.userProfileId) {
+    throw new Error("Not authenticated");
+  }
+
+  await db
+    .insert(userInterests)
+    .values({
+      userProfileId: session.userProfileId,
+      tagId,
+      weight: "1.00",
+    })
+    .onDuplicateKeyUpdate({
+      set: {
+        weight: sql`${userInterests.weight} + 1`,
+      },
+    });
+
+  revalidatePath(`/profile/${session.userProfileId}/edit`);
+}
+
+/**
+ * Remove a single interest
+ */
+export async function removeInterest(tagId: string) {
+  const session = await getSession({});
+  if (!session?.userProfileId) {
+    throw new Error("Not authenticated");
+  }
+
+  await db
+    .delete(userInterests)
+    .where(
+      and(
+        eq(userInterests.userProfileId, session.userProfileId),
+        eq(userInterests.tagId, tagId)
+      )
+    );
+
+  revalidatePath(`/profile/${session.userProfileId}/edit`);
 }

--- a/src/server/actions/vote.ts
+++ b/src/server/actions/vote.ts
@@ -13,6 +13,7 @@ import {
   type voteValue,
 } from "../db/schema/tables";
 import { increment } from "../db/utils";
+import { updateInterestsFromVote } from "./interests";
 
 export interface PrevState {
   score: number;
@@ -50,6 +51,7 @@ export default async function vote(prevState: PrevState, formData: FormData) {
           votesTable: postVotes,
           votesTableContentIdColumn: "postId",
           votesTableContentIdCondition: eq(postVotes.postId, data.postId),
+          isPost: true,
         }
       : {
           contentId: data.commentId,
@@ -60,9 +62,10 @@ export default async function vote(prevState: PrevState, formData: FormData) {
             commentVotes.commentId,
             data.commentId,
           ),
+          isPost: false,
         };
 
-  return await db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     const [existingVote] = await tx
       .select()
       .from(target.votesTable)
@@ -132,6 +135,37 @@ export default async function vote(prevState: PrevState, formData: FormData) {
     return {
       score: prevState.score + calculateDelta("up") - calculateDelta("down"),
       value: newVote,
-    } satisfies PrevState;
+      existingVoteValue: existingVote?.value ?? null,
+      newVoteValue: newVote,
+    };
   });
+
+  // Update interest weights for posts only (not comments)
+  if (target.isPost) {
+    const wasUpvote = result.existingVoteValue === "up";
+
+    if (result.newVoteValue) {
+      // New vote or changed vote
+      const isUpvote = result.newVoteValue === "up";
+      const previousVoteWasUpvote = result.existingVoteValue ? wasUpvote : null;
+
+      await updateInterestsFromVote(
+        target.contentId,
+        isUpvote,
+        previousVoteWasUpvote,
+      );
+    } else if (result.existingVoteValue) {
+      // Removed vote - reverse the previous weight change
+      await updateInterestsFromVote(
+        target.contentId,
+        !wasUpvote,
+        null,
+      );
+    }
+  }
+
+  return {
+    score: result.score,
+    value: result.value,
+  } satisfies PrevState;
 }


### PR DESCRIPTION
Updates user interest weights based on voting behavior and adds ability to edit interests in profile settings.

## Changes

### Vote-based Interest Updates
- `server/actions/vote.ts`: Call updateInterestsFromVote() after voting on posts
- `server/actions/interests.ts`: Updated updateInterestsFromVote() with simplified weight logic
- `lib/recommendations/constants.ts`: Simplified to UPVOTE (+0.5) and DOWNVOTE (-0.5)

### Profile Interest Editing
- `components/EditInterests.tsx`: New component for adding/removing interests
- `server/actions/interests.ts`: Added addInterest() and removeInterest() functions
- `app/profile/[profileId]/edit/page.tsx`: Added interests section to edit page

## How It Works

### Voting Updates Weights
| Action | Weight Change |
|--------|---------------|
| Upvote | +0.5 |
| Downvote | -0.5 |
| Upvote → Downvote | -1.0 |
| Downvote → Upvote | +1.0 |
| Remove upvote | -0.5 |
| Remove downvote | +0.5 |